### PR TITLE
Add skeleton backend and Streamlit UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,17 @@
 Installation rapide :
 ```bash
 pip install -r requirements.txt
+```
+
+## 🚀 Lancer l'application
+
+1. Démarrer l'API FastAPI :
+   ```bash
+   python backend/main.py
+   ```
+2. Ouvrir l'interface Streamlit dans un autre terminal :
+   ```bash
+   streamlit run streamlit_app/main.py
+   ```
+
+Ensuite, chargez une image depuis l'interface pour tester l'extraction.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,41 @@
+from fastapi import FastAPI, File, UploadFile
+from fastapi.responses import JSONResponse
+import tempfile
+from typing import Dict
+from src.familysearch_addon import birth_record_json_to_gedcom
+
+app = FastAPI(title="FamilySearch Addon API")
+
+
+def dummy_extract(path: str) -> Dict[str, str]:
+    """Placeholder extraction using a static result.
+
+    In a real implementation this would call the LLaVA/Ollama
+    pipeline to extract text from the uploaded image.
+    """
+    return {
+        "name": "John Doe",
+        "gender": "M",
+        "birth_date": "1 Jan 1900",
+        "birth_place": "Paris",
+    }
+
+
+@app.post("/upload")
+async def upload(file: UploadFile = File(...)):
+    """Receive a file and return extracted JSON and GEDCOM."""
+    suffix = file.filename.split(".")[-1]
+    with tempfile.NamedTemporaryFile(delete=False, suffix=f".{suffix}") as tmp:
+        tmp.write(await file.read())
+        temp_path = tmp.name
+
+    record = dummy_extract(temp_path)
+    gedcom = birth_record_json_to_gedcom(record)
+
+    return JSONResponse({"json": record, "gedcom": gedcom})
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/streamlit_app/main.py
+++ b/streamlit_app/main.py
@@ -1,0 +1,21 @@
+import streamlit as st
+import requests
+
+st.title("FamilySearch Addon")
+
+uploaded = st.file_uploader("Upload image or PDF", type=["png", "jpg", "jpeg", "pdf"])
+
+if uploaded is not None:
+    st.image(uploaded, caption="Uploaded document")
+
+    if st.button("Process with backend"):
+        files = {"file": uploaded.getvalue()}
+        resp = requests.post("http://localhost:8000/upload", files=files)
+        if resp.status_code == 200:
+            data = resp.json()
+            st.subheader("Extracted JSON")
+            st.json(data["json"])
+            st.subheader("GEDCOM")
+            st.code(data["gedcom"], language="text")
+        else:
+            st.error(f"Backend error: {resp.text}")


### PR DESCRIPTION
## Summary
- implement simple FastAPI backend with `/upload` endpoint
- add a basic Streamlit interface that sends files to the backend
- extend README with instructions on how to run the demo

## Testing
- `python -m py_compile backend/main.py streamlit_app/main.py src/familysearch_addon/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cd27f9d988332b41b03f893a669e1