### PR TITLE
Add upload validation and extraction error handling

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, File, UploadFile
+from fastapi import FastAPI, File, UploadFile, HTTPException
 from fastapi.responses import JSONResponse
 import tempfile
 from typing import Dict
@@ -24,13 +24,20 @@ def dummy_extract(path: str) -> Dict[str, str]:
 @app.post("/upload")
 async def upload(file: UploadFile = File(...)):
     """Receive a file and return extracted JSON and GEDCOM."""
+    allowed_types = {"image/png", "image/jpeg", "application/pdf"}
+    if file.content_type not in allowed_types:
+        raise HTTPException(status_code=400, detail="Unsupported file type")
+
     suffix = file.filename.split(".")[-1]
     with tempfile.NamedTemporaryFile(delete=False, suffix=f".{suffix}") as tmp:
         tmp.write(await file.read())
         temp_path = tmp.name
 
-    record = dummy_extract(temp_path)
-    gedcom = birth_record_json_to_gedcom(record)
+    try:
+        record = dummy_extract(temp_path)
+        gedcom = birth_record_json_to_gedcom(record)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
     return JSONResponse({"json": record, "gedcom": gedcom})
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,44 @@
+"""Tests for the upload endpoint."""
+
+import asyncio
+import io
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+import fastapi.dependencies.utils as fdu
+
+# Skip the runtime check for python-multipart during tests.
+fdu.ensure_multipart_is_installed = lambda: None
+
+import backend.main as main
+
+
+def test_upload_rejects_invalid_file_type():
+    file = UploadFile(
+        file=io.BytesIO(b"data"),
+        filename="test.txt",
+        headers={"content-type": "text/plain"},
+    )
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(main.upload(file))
+    assert exc.value.status_code == 400
+
+
+def test_upload_handles_extraction_failure(monkeypatch):
+    file = UploadFile(
+        file=io.BytesIO(b"data"),
+        filename="test.png",
+        headers={"content-type": "image/png"},
+    )
+
+    def _fail(path: str):  # pragma: no cover - used only for testing
+        raise Exception("boom")
+
+    monkeypatch.setattr(main, "dummy_extract", _fail)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(main.upload(file))
+    assert exc.value.status_code == 500
+    assert "boom" in exc.value.detail
+


### PR DESCRIPTION
## Summary
- reject unsupported upload content types
- return 500 responses on extraction or GEDCOM failures
- test invalid file types and extraction errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689061ec31788332a1c47c51e0eef235