### PR TITLE
feat: make API URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,7 @@ pip install -r requirements.txt
    streamlit run streamlit_app/main.py
    ```
 
+   L'URL de l'API peut être personnalisée via la variable d'environnement
+   `API_URL` (par défaut `http://localhost:8000`).
+
 Ensuite, chargez une image depuis l'interface pour tester l'extraction.

--- a/streamlit_app/main.py
+++ b/streamlit_app/main.py
@@ -1,5 +1,8 @@
+import os
 import streamlit as st
 import requests
+
+API_URL = os.getenv("API_URL", "http://localhost:8000")
 
 st.title("FamilySearch Addon")
 
@@ -10,7 +13,7 @@ if uploaded is not None:
 
     if st.button("Process with backend"):
         files = {"file": uploaded.getvalue()}
-        resp = requests.post("http://localhost:8000/upload", files=files)
+        resp = requests.post(f"{API_URL}/upload", files=files)
         if resp.status_code == 200:
             data = resp.json()
             st.subheader("Extracted JSON")


### PR DESCRIPTION
## Summary
- allow API URL configuration via API_URL environment variable
- document API_URL in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689061ecbf1083329d9b9b4ceaa70769