### PR TITLE
docs: clarify security reporting and usage

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,20 @@
 # Security Policy
 
-## Supported Versions
+## Supported version
 
-Security fixes are applied to the `main` branch.
+Security fixes target the current default branch. This repository is an
+experimental browser addon and is not an official FamilySearch product.
 
-## Reporting a Vulnerability
+## Reporting a vulnerability
 
-Please report sensitive findings privately to the repository owner. Include the affected endpoint, file type, dependency, or extraction path and a concise reproduction.
+Use GitHub's private vulnerability reporting or open a private security
+advisory in this repository. Do not publish session data, family-tree records,
+personal information, or account credentials in a public issue.
 
-Do not include real civil records, personal genealogy data, API keys, or FamilySearch credentials.
+Include the affected browser and version, impact, reproduction steps, and a
+minimal redacted example when possible.
+
+## Privacy boundaries
+
+Use test or non-sensitive data while evaluating the addon. Review requested
+browser permissions and FamilySearch terms before use.


### PR DESCRIPTION
### What Problem This Solves

The experimental addon needed clearer privacy and unofficial-product boundaries in its security guidance.

### Why This Change Was Made

Expanded the policy with private reporting, privacy boundaries, and experimental-product status.

### User Impact

No runtime behavior changes. Reporters get a safer disclosure path and users get clearer operational boundaries.

### Evidence

- Before: security reporting or licensing guidance was incomplete.
- Tests: documentation-only change; no execution path modified.
- Checks: git diff --check passed and the working tree is clean.
- Autoreview: Qodo was not run because it is unavailable; local review found no unresolved issue.